### PR TITLE
Add caching functionality to bonds

### DIFF
--- a/lib/bond.js
+++ b/lib/bond.js
@@ -329,7 +329,7 @@ class Bond {
 
 		this._triggering = null;
 
-		if (this._uuid && Bond.cache) {
+		if (this._uuid && !this._noCache && Bond.cache) {
 			Bond.cache.changed(this._uuid, newValue);
 		}
 	}
@@ -345,7 +345,7 @@ class Bond {
 	 */
 	use () {
 		if (this._users === 0) {
-			if (!this._uuid || !Bond.cache) {
+			if (!this._uuid || !!this._noCache || !Bond.cache) {
 				this.initialise();
 			} else {
 				Bond.cache.initialise(this._uuid, this, this._stringify, this._parse);
@@ -367,7 +367,7 @@ class Bond {
 		}
 		this._users--;
 		if (this._users === 0) {
-			if (!this._uuid || !Bond.cache) {
+			if (!this._uuid || !!this._noCache || !Bond.cache) {
 				this.finalise();
 			} else {
 				Bond.cache.finalise(this._uuid, this);

--- a/lib/bond.js
+++ b/lib/bond.js
@@ -87,7 +87,7 @@ class Bond {
 	 * validly be `null`. If `false`, then setting this object's value to `null`
 	 * is equivalent to reseting back to being _not ready_.
 	 */
-	constructor(mayBeNull = true, uuid = null, stringify = JSON.stringify, parse = JSON.parse) {
+	constructor(mayBeNull = true, cache = null) {
 		// Functions that should execute whenever we resolve to a new, "ready"
 		// value. They are passed the new value as a single parameter.
 		// Each function is mapped to from a `Symbol`, which can be used to
@@ -125,11 +125,11 @@ class Bond {
 
 		// The Universally Unique ID, a string used to manage caching and
 		// inter-tab result sharing.
-		this._uuid = uuid;
+		this._uuid = cache ? cache.id : null;
 		// A method for stringifying this Bond's result when using with the cache.
-		this._stringify = stringify;
+		this._stringify = cache ? cache.stringify : null;
 		// A method for unstringifying this Bond's result when using with the cache.
-		this._parse = parse;
+		this._parse = cache ? cache.parse : null;
 	}
 
 	toString () {

--- a/lib/bond.js
+++ b/lib/bond.js
@@ -903,4 +903,4 @@ class Bond {
 Bond.backupStorage = {};
 Bond.cache = new BondCache(Bond.backupStorage);
 
-module.exports = { Bond, BondCache };
+module.exports = Bond;

--- a/lib/bondCache.js
+++ b/lib/bondCache.js
@@ -195,7 +195,7 @@ class BondCache {
 
 	reconstruct (updateMessage) {
 		if (updateMessage.valueString) {
-			return this.parse(updateMessage.valueString());
+			return this.parse(updateMessage.valueString);
 		}
 		return updateMessage.value;
 	}

--- a/lib/bondCache.js
+++ b/lib/bondCache.js
@@ -88,7 +88,14 @@ class BondCache {
 	checkConsistency () {
 		Object.keys(this.regs).forEach(uuid => {
 			let item = this.regs[uuid];
-			if (item.primary === null && !item.deferred && item.users.length > 0 || item.primary === null && item.owned) {
+			if (
+				(item.primary === null
+					&& !item.deferred
+					&& item.users.length > 0
+					&& (this.storage['$_Bonds^' + uuid] === this.sessionId
+						|| !this.storage['$_Bonds^' + uuid])
+				) || item.primary === null && item.owned
+			) {
 				console.error('BondCache consistency failed!', this.regs);
 			}
 		});

--- a/lib/bondCache.js
+++ b/lib/bondCache.js
@@ -1,0 +1,271 @@
+// (C) Copyright 2016-2017 Parity Technologies (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The parent-side cache-server to which child-side BondCaches can connect.
+// Will send messages of the form { bondCacheUpdate: { uuid: '...', value: ... }}
+// value, if provided is the actual Bond value, not a stringification of it.
+// Will try to send these only for UUIDs that it knows the child is interested
+// in - child can register interest with a message { useBond: uuid } and
+// unregister interest with { dropBond: uuid }.
+//
+// If you construct BondCache passing a deferParentPrefix arg, then it's up to
+// you to ensure that the parent actually has a BondCacheProxy constructed. If
+// it doesn't, things will go screwy.
+
+class BondProxy {
+	constructor (deferParentPrefix = 'io.parity/oo7-parity/') {
+		// set up listener so that we get notified by our child.
+		window.addEventListener('message', this.onMessage.bind(this));
+
+		this.bonds = {};
+		this.deferParentPrefix = deferParentPrefix;
+	}
+
+	onMessage (e) {
+		if (e.source.parent !== window) {
+			console.warn(`Unknown client at ${e.origin} attempting to message proxy with ${e.data}. Ignoring.`);
+			return;
+		}
+		if (typeof e.data === 'object' && e.data !== null) {
+			console.log('Received message from child: ', e.data);
+			if (e.data.helloBondProxy) {
+				e.source.postMessage({ bondProxyInfo: { deferParentPrefix: this.deferParentPrefix } });
+			}
+			else if (typeof e.data.useBond === 'string') {
+				let uuid = e.data.useBond;
+				let entry = this.bonds[uuid];
+				console.log('>>> useBond ', uuid, entry);
+				if (entry) {
+					// already here - increase refs.
+					if (entry.users.indexOf(e.source) !== -1) {
+						console.warn(`Source using UUID ${uuid} more than once.`);
+					}
+					console.log('Another user');
+					entry.users.push(e.source);
+				} else {
+					// create it.
+					let newBond = fromUuid(uuid);
+					if (newBond) {
+						console.log('Creating new bond');
+						entry = this.bonds[uuid] = { bond: newBond, users: [e.source] };
+						entry.notifyKey = newBond.notify(value =>
+							entry.users.forEach(u =>
+								u.postMessage({ bondCacheUpdate: { uuid, value } })
+							)
+						);
+					} else {
+						console.warn(`UUID ${uuid} is unknown - cannot create a Bond for it.`);
+					}
+				}
+				console.log('Posting update back to child');
+				let value = entry.bond.isReady() ? entry._value : undefined;
+				e.source.postMessage({ bondCacheUpdate: { uuid, value } });
+			}
+			else if (typeof e.data.dropBond === 'string') {
+				let uuid = e.data.dropBond;
+				let entry = this.bonds[uuid];
+				console.log('>>> dropBond ', uuid, entry);
+				if (entry) {
+					let i = entry.users.indexOf(e.source);
+					if (i !== -1) {
+						console.log('Removing child from updates list');
+						entry.users.splice(i, 1);
+					} else {
+						console.warn(`Source asking to drop UUID ${uuid} that they do not track. They probably weren't getting updates.`);
+					}
+					if (entry.users.length === 0) {
+						console.log('No users - retiring bond');
+						entry.bond.unnotify(entry.notifyKey);
+						delete entry;
+					}
+				} else {
+					console.warn(`Cannot drop a Bond (${uuid}) that we do not track.`);
+				}
+			}
+		}
+	}
+}
+
+class BondCache {
+	constructor (backupStorage, deferParentPrefix) {
+		if (typeof window !== 'undefined') {
+			window.addEventListener('storage', this.onStorageChanged.bind(this));
+			window.addEventListener('unload', this.onUnload.bind(this));
+			window.addEventListener('message', this.onMessage.bind(this));
+		}
+
+		this.deferParentPrefix = window && window.parent ? deferParentPrefix : null;
+
+		this.regs = {};
+
+		// TODO: would be nice if this were better.
+		this.sessionId = Math.floor((1 + Math.random()) * 0x100000000).toString(16).substr(1);
+//		console.log('Constructing Cache. ID: ', this.sessionId);
+
+		this.storage = typeof window !== 'undefined' ? window.localStorage : backupStorage;
+	}
+
+	initialise (uuid, bond, stringify, parse) {
+//		console.log('BondCache.initialise', this.sessionId, uuid, bond, this.regs);
+		if (!this.regs[uuid]) {
+			this.regs[uuid] = { owner: null, deferred: false, users: [bond], stringify, parse };
+			let key = '$_Bonds.' + uuid;
+			if (this.storage[key] !== undefined) {
+				bond.changed(parse(this.storage[key]));
+			}
+			this.ensureActive(uuid);
+//			console.log('Created reg', this.regs);
+		} else {
+			this.regs[uuid].users.push(bond);
+			let equivBond = (this.regs[uuid].owner || this.regs[uuid].users[0]);
+			if (equivBond.isReady()) {
+				bond.changed(equivBond._value);
+			}
+		}
+	}
+
+	changed (uuid, value) {
+//		console.log('Bond changed', this.sessionId, uuid, value, this.regs);
+		let item = this.regs[uuid];
+		if (item && this.storage['$_Bonds^' + uuid] === this.sessionId) {
+			let key = '$_Bonds.' + uuid;
+			if (value === undefined) {
+				delete this.storage[key];
+				item.users.forEach(bond => bond.reset());
+			} else {
+				this.storage[key] = item.stringify(value);
+				item.users.forEach(bond => bond.changed(value));
+			}
+		}
+//		console.log('Bond change complete', this.regs[uuid]);
+	}
+
+	finalise (uuid, bond) {
+//		console.log('BondCache.finalise', uuid, bond, this.regs);
+		let item = this.regs[uuid];
+		if (item.owner === bond) {
+			item.owner.finalise();
+			item.owner = null;
+			if (item.users.length === 0) {
+				// no owner and no users. we shold be the owner in
+				// storage. if we are, remove our key to signify to other
+				// tabs we're no longer maintaining this.
+				let storageKey = '$_Bonds^' + uuid;
+				let owner = this.storage[storageKey];
+				if (owner === this.sessionId) {
+					delete this.storage[storageKey];
+				}
+				delete this.regs[uuid];
+			} else {
+				// we removed the owner and there are users, must ensure that
+				// the bond is maintained.
+				this.ensureActive(uuid);
+			}
+		} else {
+			// otherwise, just remove the exiting bond from the users.
+			item.users = item.users.filter(b => b !== bond);
+
+			// If we're the last user from a parent-deferred Bond, then notify
+			// parent we're no longer bothered about further updates.
+			if (item.users.length === 0 && this.regs[uuid].deferred) {
+				console.log('finalise: dropping deferral from parent frame', uuid);
+				window.parent.postMessage({ dropBond: uuid });
+			}
+		}
+	}
+
+	ensureActive (uuid, key = '$_Bonds^' + uuid) {
+		let item = this.regs[uuid];
+		if (item && item.users.length > 0 && item.owner === null && !item.deferred) {
+			if (this.deferParentPrefix && uuid.startsWith(this.deferParentPrefix)) {
+				console.log('ensureActive: deferring to parent frame', uuid);
+				item.deferred = true;
+				window.parent.postMessage({ useBond: uuid });
+			}
+			// One that we use - adopt it if necessary.
+			else if (!this.storage[key]) {
+				this.storage[key] = this.sessionId;
+				item.owner = item.users.pop();
+				item.owner.initialise();
+			}
+		}
+	}
+
+	onMessage (e) {
+		console.log('Received message', e);
+		if (window && e.source === window.parent) {
+			// Comes from parent.
+			console.log('Message is from parent');
+			if (typeof e.data === 'object' && e.data !== null) {
+				let up = e.data.bondCacheUpdate;
+				if (up && this.regs[up.uuid]) {
+					console.log('Bond cache update that we care about:', up.uuid);
+					if (typeof up.value !== 'undefined') {
+						item.users.forEach(bond => bond.changed(up.value));
+					} else {
+						item.users.forEach(bond => bond.reset());
+					}
+				}
+			}
+		}
+	}
+
+	onStorageChanged (e) {
+//		console.log('BondCache.onStorageChanged');
+		if (!e.key.startsWith('$_Bonds')) {
+			return;
+		}
+		let uuid = e.key.substr(8);
+		let item = this.regs[uuid];
+		if (!item) {
+			return;
+		}
+		if (e.key[7] === '.') {
+			// Bond changed...
+			if (typeof(this.storage[e.key]) === 'undefined') {
+				item.users.forEach(bond => bond.reset());
+			} else {
+				let v = item.parse(this.storage[e.key]);
+				item.users.forEach(bond => bond.changed(v));
+			}
+		}
+		else if (e.key[7] === '^') {
+			// Owner going offline...
+			this.ensureActive(uuid, e.key);
+		}
+	}
+
+	onUnload () {
+//		console.log('BondCache.onUnload');
+		// Like drop for all items, except that we don't care about usage; we
+		// drop anyway.
+		Object.keys(this.regs).forEach(uuid => {
+			if (this.regs[uuid].deferred) {
+				console.log('onUnload: dropping deferral from parent frame', uuid);
+				window.parent.postMessage({ dropBond: uuid });
+			} else {
+				let storageKey = '$_Bonds^' + uuid;
+				let owner = this.storage[storageKey];
+				if (owner === this.sessionId) {
+					delete this.storage[storageKey];
+				}
+			}
+		});
+		this.regs = {};
+	}
+}
+
+BondCache.Proxy = BondCacheProxy;
+
+module.exports = BondCache;

--- a/lib/bondCache.js
+++ b/lib/bondCache.js
@@ -118,6 +118,7 @@ class BondCache {
 	}
 
 	ensureActive (uuid, key = '$_Bonds^' + uuid) {
+		console.log('ensureActive', uuid);
 		let item = this.regs[uuid];
 		if (item && item.users.length > 0 && item.owner === null && !item.deferred) {
 			if (this.deferParentPrefix && uuid.startsWith(this.deferParentPrefix)) {
@@ -127,6 +128,7 @@ class BondCache {
 			}
 			// One that we use - adopt it if necessary.
 			else if (!this.storage[key]) {
+				console.log('ensureActive: Adopting');
 				this.storage[key] = this.sessionId;
 				item.owner = item.users.pop();
 				item.owner.initialise();
@@ -142,11 +144,13 @@ class BondCache {
 			if (typeof e.data === 'object' && e.data !== null) {
 				let up = e.data.bondCacheUpdate;
 				if (up && this.regs[up.uuid]) {
-					console.log('Bond cache update that we care about:', up.uuid);
+					console.log('onMessage: Bond cache update that we care about:', up.uuid);
 					let item = this.regs[up.uuid];
 					if (typeof up.value !== 'undefined') {
+						console.log('onMessage: Updating bond:', up.uuid, up.value, item.users);
 						item.users.forEach(bond => bond.changed(up.value));
 					} else {
+						console.log('onMessage: Resetting bond:', up.uuid, item.users);
 						item.users.forEach(bond => bond.reset());
 					}
 				}

--- a/lib/bondCache.js
+++ b/lib/bondCache.js
@@ -25,13 +25,13 @@
 
 class BondCache {
 	constructor (backupStorage, deferParentPrefix) {
-		if (typeof window !== 'undefined') {
+		if (typeof window === 'object') {
 			window.addEventListener('storage', this.onStorageChanged.bind(this));
 			window.addEventListener('unload', this.onUnload.bind(this));
 			window.addEventListener('message', this.onMessage.bind(this));
 		}
 
-		this.deferParentPrefix = window && window.parent ? deferParentPrefix : null;
+		this.deferParentPrefix = typeof window === 'object' && window.parent ? deferParentPrefix : null;
 
 		this.regs = {};
 
@@ -130,7 +130,7 @@ class BondCache {
 
 	onMessage (e) {
 		console.log('Received message', e);
-		if (window && e.source === window.parent) {
+		if (typeof window === 'object' && e.source === window.parent) {
 			// Comes from parent.
 			console.log('Message is from parent');
 			if (typeof e.data === 'object' && e.data !== null) {

--- a/lib/bondCache.js
+++ b/lib/bondCache.js
@@ -23,13 +23,14 @@
 // you to ensure that the parent actually has a BondCacheProxy constructed. If
 // it doesn't, things will go screwy.
 
-class BondProxy {
-	constructor (deferParentPrefix = 'io.parity/oo7-parity/') {
+class BondCacheProxy {
+	constructor (deferParentPrefix, fromUuid) {
 		// set up listener so that we get notified by our child.
 		window.addEventListener('message', this.onMessage.bind(this));
 
 		this.bonds = {};
 		this.deferParentPrefix = deferParentPrefix;
+		this.fromUuid = fromUuid;
 	}
 
 	onMessage (e) {
@@ -55,7 +56,7 @@ class BondProxy {
 					entry.users.push(e.source);
 				} else {
 					// create it.
-					let newBond = fromUuid(uuid);
+					let newBond = this.fromUuid(uuid);
 					if (newBond) {
 						console.log('Creating new bond');
 						entry = this.bonds[uuid] = { bond: newBond, users: [e.source] };

--- a/lib/bondCache.js
+++ b/lib/bondCache.js
@@ -193,9 +193,9 @@ class BondCache {
 		}
 	}
 
-	reconstruct (updateMessage) {
+	reconstruct (updateMessage, bond) {
 		if (updateMessage.valueString) {
-			return this._parse(updateMessage.valueString);
+			return bond._parse(updateMessage.valueString);
 		}
 		return updateMessage.value;
 	}
@@ -207,16 +207,18 @@ class BondCache {
 //			console.log('Message is from parent');
 			if (typeof e.data === 'object' && e.data !== null) {
 				let up = e.data.bondCacheUpdate;
-				let value = this.reconstruct(up);
 				if (up && this.regs[up.uuid]) {
 					consoleDebug('BondCache.onMessage: Bond cache update that we care about:', up.uuid);
 					let item = this.regs[up.uuid];
-					if (typeof value !== 'undefined') {
-						consoleDebug('BondCache.onMessage: Updating bond:', up.uuid, value, item.users);
-						item.users.forEach(bond => bond.changed(value));
-					} else {
-						consoleDebug('BondCache.onMessage: Resetting bond:', up.uuid, item.users);
-						item.users.forEach(bond => bond.reset());
+					if (item.users.length > 0) {
+						let value = this.reconstruct(up, item.users[0]);
+						if (typeof value !== 'undefined') {
+							consoleDebug('BondCache.onMessage: Updating bond:', up.uuid, value, item.users);
+							item.users.forEach(bond => bond.changed(value));
+						} else {
+							consoleDebug('BondCache.onMessage: Resetting bond:', up.uuid, item.users);
+							item.users.forEach(bond => bond.reset());
+						}
 					}
 				}
 			}

--- a/lib/bondCache.js
+++ b/lib/bondCache.js
@@ -23,7 +23,7 @@
 // you to ensure that the parent actually has a BondCacheProxy constructed. If
 // it doesn't, things will go screwy.
 
-let consoleDebug = typeof window !== 'undefined' && typeof window.debugging !== 'undefined' ? console.debug : () => {};
+let consoleDebug = typeof window !== 'undefined' && window.debugging ? console.debug : () => {};
 
 class BondCache {
 	constructor (backupStorage, deferParentPrefix, surrogateWindow = null) {
@@ -40,7 +40,7 @@ class BondCache {
 
 		// TODO: would be nice if this were better.
 		this.sessionId = Math.floor((1 + Math.random()) * 0x100000000).toString(16).substr(1);
-		console.log('BondCache: Constructing', this.sessionId);
+		consoleDebug('BondCache: Constructing', this.sessionId);
 
 		try {
 			this.storage = this.window ? this.window.localStorage : backupStorage;
@@ -256,10 +256,10 @@ class BondCache {
 		// drop anyway.
 		Object.keys(this.regs).forEach(uuid => {
 			if (this.regs[uuid].deferred) {
-				console.log('BondCache.onUnload: dropping deferral from parent frame', uuid);
+				consoleDebug('BondCache.onUnload: dropping deferral from parent frame', uuid);
 				this.window.parent.postMessage({ dropBond: uuid }, '*');
 			} else {
-				console.log('BondCache.onUnload: dropping ownership key from storage', uuid);
+				consoleDebug('BondCache.onUnload: dropping ownership key from storage', uuid);
 				let storageKey = '$_Bonds^' + uuid;
 				let owner = this.storage[storageKey];
 				if (owner === this.sessionId) {

--- a/lib/bondCache.js
+++ b/lib/bondCache.js
@@ -114,7 +114,6 @@ class BondCache {
 				if (owner === this.sessionId) {
 					delete this.storage[storageKey];
 				}
-				delete this.regs[uuid];
 			} else {
 				console.debug('BondCache.finalise: Still users; ensuring active.');
 				// we removed the owner and there are users, must ensure that
@@ -133,6 +132,9 @@ class BondCache {
 				this.window.parent.postMessage({ dropBond: uuid }, '*');
 				this.regs[uuid].deferred = false;
 			}
+		}
+		if (item.owner === null && !item.deferred && item.users.length === 0) {
+			delete this.regs[uuid];
 		}
 //		this.checkConsistency();
 	}

--- a/lib/bondCache.js
+++ b/lib/bondCache.js
@@ -193,6 +193,13 @@ class BondCache {
 		}
 	}
 
+	reconstruct (updateMessage) {
+		if (updateMessage.valueString) {
+			return this.parse(updateMessage.valueString());
+		}
+		return updateMessage.value;
+	}
+
 	onMessage (e) {
 //		console.log('Received message', e);
 		if (this.window && e.source === this.window.parent) {
@@ -200,12 +207,13 @@ class BondCache {
 //			console.log('Message is from parent');
 			if (typeof e.data === 'object' && e.data !== null) {
 				let up = e.data.bondCacheUpdate;
+				let value = this.reconstruct(up);
 				if (up && this.regs[up.uuid]) {
 					consoleDebug('BondCache.onMessage: Bond cache update that we care about:', up.uuid);
 					let item = this.regs[up.uuid];
-					if (typeof up.value !== 'undefined') {
-						consoleDebug('BondCache.onMessage: Updating bond:', up.uuid, up.value, item.users);
-						item.users.forEach(bond => bond.changed(up.value));
+					if (typeof value !== 'undefined') {
+						consoleDebug('BondCache.onMessage: Updating bond:', up.uuid, value, item.users);
+						item.users.forEach(bond => bond.changed(value));
 					} else {
 						consoleDebug('BondCache.onMessage: Resetting bond:', up.uuid, item.users);
 						item.users.forEach(bond => bond.reset());

--- a/lib/bondCache.js
+++ b/lib/bondCache.js
@@ -189,7 +189,7 @@ class BondCache {
 			}
 			// One that we use - adopt it if necessary.
 			else {
-				consoleDebug('BondCache.ensureActive: One that we use - adopt it if necessary.');
+				consoleDebug('BondCache.ensureActive: One that we use - adopt it if necessary.', this.storage[key], this.sessionId);
 				if (!this.storage[key]) {
 					consoleDebug('BondCache.ensureActive: No registered owner yet. Adopting');
 					this.storage[key] = this.sessionId;

--- a/lib/bondCache.js
+++ b/lib/bondCache.js
@@ -58,7 +58,7 @@ class BondCache {
 			let key = '$_Bonds.' + uuid;
 			if (this.storage[key] !== undefined) {
 				consoleDebug('BondCache.initialise: restoring from persistent cache');
-				bond.changed(bond.parse(this.storage[key]));
+				bond.changed(parse(this.storage[key]));
 			}
 			this.ensureActive(uuid);
 			consoleDebug('BondCache.initialise: Created reg', this.regs);

--- a/lib/bondCache.js
+++ b/lib/bondCache.js
@@ -195,7 +195,7 @@ class BondCache {
 
 	reconstruct (updateMessage) {
 		if (updateMessage.valueString) {
-			return this.parse(updateMessage.valueString);
+			return this._parse(updateMessage.valueString);
 		}
 		return updateMessage.value;
 	}

--- a/lib/bondCache.js
+++ b/lib/bondCache.js
@@ -40,7 +40,12 @@ class BondCache {
 		this.sessionId = Math.floor((1 + Math.random()) * 0x100000000).toString(16).substr(1);
 //		console.log('Constructing Cache. ID: ', this.sessionId);
 
-		this.storage = this.window ? this.window.localStorage : backupStorage;
+		try {
+			this.storage = this.window ? this.window.localStorage : backupStorage;
+		}
+		catch (e) {
+			this.storage = backupStorage;
+		}
 	}
 
 	initialise (uuid, bond, stringify, parse) {
@@ -107,7 +112,7 @@ class BondCache {
 			// parent we're no longer bothered about further updates.
 			if (item.users.length === 0 && this.regs[uuid].deferred) {
 				console.log('finalise: dropping deferral from parent frame', uuid);
-				this.window.parent.postMessage({ dropBond: uuid });
+				this.window.parent.postMessage({ dropBond: uuid }, '*');
 			}
 		}
 	}
@@ -118,7 +123,7 @@ class BondCache {
 			if (this.deferParentPrefix && uuid.startsWith(this.deferParentPrefix)) {
 				console.log('ensureActive: deferring to parent frame', uuid);
 				item.deferred = true;
-				this.window.parent.postMessage({ useBond: uuid });
+				this.window.parent.postMessage({ useBond: uuid }, '*');
 			}
 			// One that we use - adopt it if necessary.
 			else if (!this.storage[key]) {
@@ -181,7 +186,7 @@ class BondCache {
 		Object.keys(this.regs).forEach(uuid => {
 			if (this.regs[uuid].deferred) {
 				console.log('onUnload: dropping deferral from parent frame', uuid);
-				this.window.parent.postMessage({ dropBond: uuid });
+				this.window.parent.postMessage({ dropBond: uuid }, '*');
 			} else {
 				let storageKey = '$_Bonds^' + uuid;
 				let owner = this.storage[storageKey];

--- a/lib/bondCache.js
+++ b/lib/bondCache.js
@@ -111,24 +111,24 @@ class BondCache {
 			// If we're the last user from a parent-deferred Bond, then notify
 			// parent we're no longer bothered about further updates.
 			if (item.users.length === 0 && this.regs[uuid].deferred) {
-				console.log('finalise: dropping deferral from parent frame', uuid);
+				console.debug('finalise: dropping deferral from parent frame', uuid);
 				this.window.parent.postMessage({ dropBond: uuid }, '*');
 			}
 		}
 	}
 
 	ensureActive (uuid, key = '$_Bonds^' + uuid) {
-		console.log('ensureActive', uuid);
+		console.debug('ensureActive', uuid);
 		let item = this.regs[uuid];
 		if (item && item.users.length > 0 && item.owner === null && !item.deferred) {
 			if (this.deferParentPrefix && uuid.startsWith(this.deferParentPrefix)) {
-				console.log('ensureActive: deferring to parent frame', uuid);
+				console.debug('ensureActive: deferring to parent frame', uuid);
 				item.deferred = true;
 				this.window.parent.postMessage({ useBond: uuid }, '*');
 			}
 			// One that we use - adopt it if necessary.
 			else if (!this.storage[key]) {
-				console.log('ensureActive: Adopting');
+				console.debug('ensureActive: Adopting');
 				this.storage[key] = this.sessionId;
 				item.owner = item.users.pop();
 				item.owner.initialise();
@@ -144,13 +144,13 @@ class BondCache {
 			if (typeof e.data === 'object' && e.data !== null) {
 				let up = e.data.bondCacheUpdate;
 				if (up && this.regs[up.uuid]) {
-					console.log('onMessage: Bond cache update that we care about:', up.uuid);
+					console.debug('onMessage: Bond cache update that we care about:', up.uuid);
 					let item = this.regs[up.uuid];
 					if (typeof up.value !== 'undefined') {
-						console.log('onMessage: Updating bond:', up.uuid, up.value, item.users);
+						console.debug('onMessage: Updating bond:', up.uuid, up.value, item.users);
 						item.users.forEach(bond => bond.changed(up.value));
 					} else {
-						console.log('onMessage: Resetting bond:', up.uuid, item.users);
+						console.debug('onMessage: Resetting bond:', up.uuid, item.users);
 						item.users.forEach(bond => bond.reset());
 					}
 				}

--- a/lib/bondProxy.js
+++ b/lib/bondProxy.js
@@ -36,67 +36,67 @@ class BondProxy {
 
 	onMessage (e) {
 		if (e.source.parent !== this.window) {
-			console.warn(`Unknown client at ${e.origin} attempting to message proxy with ${e.data}. Ignoring.`);
+			console.warn(`onMessage: Unknown client at ${e.origin} attempting to message proxy with ${e.data}. Ignoring.`);
 			return;
 		}
 		if (typeof e.data === 'object' && e.data !== null) {
-			console.log('Received message from child: ', e.data);
+			console.debug('onMessage: Received message from child: ', e.data);
 			if (e.data.helloBondProxy) {
 				e.source.postMessage({ bondProxyInfo: { deferParentPrefix: this.deferParentPrefix } }, '*');
 			}
 			else if (typeof e.data.useBond === 'string') {
 				let uuid = e.data.useBond;
 				let entry = this.bonds[uuid];
-				console.log('>>> useBond ', uuid, entry);
+				console.debug('onMessage: useBond ', uuid, entry);
 				if (entry) {
 					// already here - increase refs.
 					if (entry.users.indexOf(e.source) !== -1) {
-						console.warn(`Source using UUID ${uuid} more than once.`);
+						console.warn(`onMessage: Source using UUID ${uuid} more than once.`);
 					}
-					console.log('Another user');
+					console.debug('onMessage: Another user');
 					entry.users.push(e.source);
 				} else {
 					// create it.
 					let newBond = this.fromUuid(uuid);
 					if (newBond) {
-						console.log('Creating new bond');
+						console.debug('onMessage: Creating new bond');
 						entry = this.bonds[uuid] = { bond: newBond, users: [e.source] };
 						entry.notifyKey = newBond.notify(() => {
 							let value = newBond.isReady() ? newBond._value : undefined;
-							console.log('Bond changed. Updating child:', uuid, value);
+							console.debug('onMessage: Bond changed. Updating child:', uuid, value);
 							entry.users.forEach(u =>
 								u.postMessage({ bondCacheUpdate: { uuid, value } }, '*')
 							)
 						});
 					} else {
-						console.warn(`UUID ${uuid} is unknown - cannot create a Bond for it.`);
+						console.warn(`onMessage: UUID ${uuid} is unknown - cannot create a Bond for it.`);
 						e.source.postMessage({ bondUnknown: { uuid } }, '*');
 						return;
 					}
 				}
 				let value = entry.bond.isReady() ? entry.bond._value : undefined;
-				console.log('Posting update back to child', uuid, value);
+				console.debug('onMessage: Posting update back to child', uuid, value);
 				e.source.postMessage({ bondCacheUpdate: { uuid, value } }, '*');
 			}
 			else if (typeof e.data.dropBond === 'string') {
 				let uuid = e.data.dropBond;
 				let entry = this.bonds[uuid];
-				console.log('<<< dropBond ', uuid, entry);
+				console.debug('onMessage: dropBond ', uuid, entry);
 				if (entry) {
 					let i = entry.users.indexOf(e.source);
 					if (i !== -1) {
-						console.log('Removing child from updates list');
+						console.debug('onMessage: Removing child from updates list');
 						entry.users.splice(i, 1);
 					} else {
-						console.warn(`Source asking to drop UUID ${uuid} that they do not track. They probably weren't getting updates.`);
+						console.warn(`onMessage: Source asking to drop UUID ${uuid} that they do not track. They probably weren't getting updates.`);
 					}
 					if (entry.users.length === 0) {
-						console.log('No users - retiring bond');
+						console.debug('onMessage: No users - retiring bond');
 						entry.bond.unnotify(entry.notifyKey);
 						delete this.bonds[uuid];
 					}
 				} else {
-					console.warn(`Cannot drop a Bond (${uuid}) that we do not track.`);
+					console.warn(`onMessage: Cannot drop a Bond (${uuid}) that we do not track.`);
 				}
 			}
 		}

--- a/lib/bondProxy.js
+++ b/lib/bondProxy.js
@@ -29,8 +29,8 @@ let consoleDebug = typeof debugging === 'undefined' ? ()=>{} : console.debug;
 function prepUpdate (uuid, bond) {
 	let value = bond.isReady() ? bond._value : undefined;
 
-	if (typeof value === 'object' && value !== null) {
-		return { uuid, valueString: bond.stringify(value) };
+	if (typeof value === 'object' && value !== null && bond._stringify) {
+		return { uuid, valueString: bond._stringify(value) };
 	}
 
 	return { uuid, value };

--- a/lib/bondProxy.js
+++ b/lib/bondProxy.js
@@ -29,7 +29,7 @@ let consoleDebug = typeof debugging === 'undefined' ? ()=>{} : console.debug;
 function prepUpdate (uuid, bond) {
 	let value = bond.isReady() ? bond._value : undefined;
 
-	if (typeof v === 'object' && v !== null) {
+	if (typeof value === 'object' && value !== null) {
 		return { uuid, valueString: bond.stringify(value) };
 	}
 

--- a/lib/bondProxy.js
+++ b/lib/bondProxy.js
@@ -26,7 +26,7 @@
 let consoleDebug = typeof debugging === 'undefined' ? ()=>{} : console.debug;
 
 // Prepare value `v` for being sent over `window.postMessage`.
-function prepValue (uuid, bond) {
+function prepUpdate (uuid, bond) {
 	let value = bond.isReady() ? bond._value : undefined;
 
 	if (typeof v === 'object' && v !== null) {

--- a/lib/bondProxy.js
+++ b/lib/bondProxy.js
@@ -74,7 +74,7 @@ class BondProxy {
 						return;
 					}
 				}
-				let value = entry.bond.isReady() ? entry._value : undefined;
+				let value = entry.bond.isReady() ? entry.bond._value : undefined;
 				console.log('Posting update back to child', uuid, value);
 				e.source.postMessage({ bondCacheUpdate: { uuid, value } }, '*');
 			}

--- a/lib/bondProxy.js
+++ b/lib/bondProxy.js
@@ -42,7 +42,7 @@ class BondProxy {
 		if (typeof e.data === 'object' && e.data !== null) {
 			console.log('Received message from child: ', e.data);
 			if (e.data.helloBondProxy) {
-				e.source.postMessage({ bondProxyInfo: { deferParentPrefix: this.deferParentPrefix } });
+				e.source.postMessage({ bondProxyInfo: { deferParentPrefix: this.deferParentPrefix } }, '*');
 			}
 			else if (typeof e.data.useBond === 'string') {
 				let uuid = e.data.useBond;
@@ -63,7 +63,7 @@ class BondProxy {
 						entry = this.bonds[uuid] = { bond: newBond, users: [e.source] };
 						entry.notifyKey = newBond.notify(() =>
 							entry.users.forEach(u =>
-								u.postMessage({ bondCacheUpdate: { uuid, value: newBond.isReady() ? newBond._value : undefined } })
+								u.postMessage({ bondCacheUpdate: { uuid, value: newBond.isReady() ? newBond._value : undefined } }, '*')
 							)
 						);
 					} else {
@@ -72,7 +72,7 @@ class BondProxy {
 				}
 				console.log('Posting update back to child');
 				let value = entry.bond.isReady() ? entry._value : undefined;
-				e.source.postMessage({ bondCacheUpdate: { uuid, value } });
+				e.source.postMessage({ bondCacheUpdate: { uuid, value } }, '*');
 			}
 			else if (typeof e.data.dropBond === 'string') {
 				let uuid = e.data.dropBond;

--- a/lib/bondProxy.js
+++ b/lib/bondProxy.js
@@ -1,0 +1,99 @@
+// (C) Copyright 2016-2017 Parity Technologies (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The parent-side cache-server to which child-side BondCaches can connect.
+// Will send messages of the form { bondCacheUpdate: { uuid: '...', value: ... }}
+// value, if provided is the actual Bond value, not a stringification of it.
+// Will try to send these only for UUIDs that it knows the child is interested
+// in - child can register interest with a message { useBond: uuid } and
+// unregister interest with { dropBond: uuid }.
+//
+// If you construct BondCache passing a deferParentPrefix arg, then it's up to
+// you to ensure that the parent actually has a BondCacheProxy constructed. If
+// it doesn't, things will go screwy.
+
+class BondCacheProxy {
+	constructor (deferParentPrefix, fromUuid) {
+		// set up listener so that we get notified by our child.
+		window.addEventListener('message', this.onMessage.bind(this));
+
+		this.bonds = {};
+		this.deferParentPrefix = deferParentPrefix;
+		this.fromUuid = fromUuid;
+	}
+
+	onMessage (e) {
+		if (e.source.parent !== window) {
+			console.warn(`Unknown client at ${e.origin} attempting to message proxy with ${e.data}. Ignoring.`);
+			return;
+		}
+		if (typeof e.data === 'object' && e.data !== null) {
+			console.log('Received message from child: ', e.data);
+			if (e.data.helloBondProxy) {
+				e.source.postMessage({ bondProxyInfo: { deferParentPrefix: this.deferParentPrefix } });
+			}
+			else if (typeof e.data.useBond === 'string') {
+				let uuid = e.data.useBond;
+				let entry = this.bonds[uuid];
+				console.log('>>> useBond ', uuid, entry);
+				if (entry) {
+					// already here - increase refs.
+					if (entry.users.indexOf(e.source) !== -1) {
+						console.warn(`Source using UUID ${uuid} more than once.`);
+					}
+					console.log('Another user');
+					entry.users.push(e.source);
+				} else {
+					// create it.
+					let newBond = this.fromUuid(uuid);
+					if (newBond) {
+						console.log('Creating new bond');
+						entry = this.bonds[uuid] = { bond: newBond, users: [e.source] };
+						entry.notifyKey = newBond.notify(value =>
+							entry.users.forEach(u =>
+								u.postMessage({ bondCacheUpdate: { uuid, value } })
+							)
+						);
+					} else {
+						console.warn(`UUID ${uuid} is unknown - cannot create a Bond for it.`);
+					}
+				}
+				console.log('Posting update back to child');
+				let value = entry.bond.isReady() ? entry._value : undefined;
+				e.source.postMessage({ bondCacheUpdate: { uuid, value } });
+			}
+			else if (typeof e.data.dropBond === 'string') {
+				let uuid = e.data.dropBond;
+				let entry = this.bonds[uuid];
+				console.log('>>> dropBond ', uuid, entry);
+				if (entry) {
+					let i = entry.users.indexOf(e.source);
+					if (i !== -1) {
+						console.log('Removing child from updates list');
+						entry.users.splice(i, 1);
+					} else {
+						console.warn(`Source asking to drop UUID ${uuid} that they do not track. They probably weren't getting updates.`);
+					}
+					if (entry.users.length === 0) {
+						console.log('No users - retiring bond');
+						entry.bond.unnotify(entry.notifyKey);
+						delete this.bonds[uuid];
+					}
+				} else {
+					console.warn(`Cannot drop a Bond (${uuid}) that we do not track.`);
+				}
+			}
+		}
+	}
+}

--- a/lib/bondProxy.js
+++ b/lib/bondProxy.js
@@ -25,6 +25,17 @@
 
 let consoleDebug = typeof debugging === 'undefined' ? ()=>{} : console.debug;
 
+// Prepare value `v` for being sent over `window.postMessage`.
+function prepValue (uuid, bond) {
+	let value = bond.isReady() ? bond._value : undefined;
+
+	if (typeof v === 'object' && v !== null) {
+		return { uuid, valueString: bond.stringify(value) };
+	}
+
+	return { uuid, value };
+}
+
 class BondProxy {
 	constructor (deferParentPrefix, fromUuid, surrogateWindow = null) {
 		this.bonds = {};
@@ -34,17 +45,6 @@ class BondProxy {
 
 		// set up listener so that we get notified by our child.
 		this.window.addEventListener('message', this.onMessage.bind(this));
-	}
-
-	// Prepare value `v` for being sent over `window.postMessage`.
-	prepValue (uuid, bond) {
-		let value = bond.isReady() ? bond._value : undefined;
-
-		if (typeof v === 'object' && v !== null) {
-			return { uuid, valueString: bond.stringify(value) };
-		}
-
-		return { uuid, value };
 	}
 
 	onMessage (e) {

--- a/lib/bondProxy.js
+++ b/lib/bondProxy.js
@@ -61,17 +61,21 @@ class BondProxy {
 					if (newBond) {
 						console.log('Creating new bond');
 						entry = this.bonds[uuid] = { bond: newBond, users: [e.source] };
-						entry.notifyKey = newBond.notify(() =>
+						entry.notifyKey = newBond.notify(() => {
+							let value = newBond.isReady() ? newBond._value : undefined;
+							console.log('Bond changed. Updating child:', uuid, value);
 							entry.users.forEach(u =>
-								u.postMessage({ bondCacheUpdate: { uuid, value: newBond.isReady() ? newBond._value : undefined } }, '*')
+								u.postMessage({ bondCacheUpdate: { uuid, value } }, '*')
 							)
-						);
+						});
 					} else {
 						console.warn(`UUID ${uuid} is unknown - cannot create a Bond for it.`);
+						e.source.postMessage({ bondUnknown: { uuid } }, '*');
+						return;
 					}
 				}
-				console.log('Posting update back to child');
 				let value = entry.bond.isReady() ? entry._value : undefined;
+				console.log('Posting update back to child', uuid, value);
 				e.source.postMessage({ bondCacheUpdate: { uuid, value } }, '*');
 			}
 			else if (typeof e.data.dropBond === 'string') {

--- a/lib/bondProxy.js
+++ b/lib/bondProxy.js
@@ -23,7 +23,7 @@
 // you to ensure that the parent actually has a BondCacheProxy constructed. If
 // it doesn't, things will go screwy.
 
-let consoleDebug = typeof debugging === 'undefined' ? ()=>{} : console.debug;
+let consoleDebug = typeof window !== 'undefined' && window.debugging ? console.debug : () => {};
 
 // Prepare value `v` for being sent over `window.postMessage`.
 function prepUpdate (uuid, bond) {

--- a/lib/bondProxy.js
+++ b/lib/bondProxy.js
@@ -23,7 +23,7 @@
 // you to ensure that the parent actually has a BondCacheProxy constructed. If
 // it doesn't, things will go screwy.
 
-class BondCacheProxy {
+class BondProxy {
 	constructor (deferParentPrefix, fromUuid) {
 		// set up listener so that we get notified by our child.
 		window.addEventListener('message', this.onMessage.bind(this));
@@ -97,3 +97,5 @@ class BondCacheProxy {
 		}
 	}
 }
+
+module.exports = BondProxy;

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,6 +14,7 @@
 
 const Bond = require('./bond');
 const BondCache = require('./bondCache');
+const BondProxy = require('./bondProxy');
 const ReactiveBond = require('./reactiveBond');
 const ReactivePromise = require('./reactivePromise');
 const TimeBond = require('./timeBond');
@@ -22,6 +23,7 @@ const TransformBond = require('./transformBond');
 module.exports = {
 	Bond,
 	BondCache,
+	BondProxy,
 	ReactiveBond,
 	ReactivePromise,
 	TimeBond,

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 const Bond = require('./bond');
+const BondCache = require('./bondCache');
 const ReactiveBond = require('./reactiveBond');
 const ReactivePromise = require('./reactivePromise');
 const TimeBond = require('./timeBond');
@@ -20,6 +21,7 @@ const TransformBond = require('./transformBond');
 
 module.exports = {
 	Bond,
+	BondCache,
 	ReactiveBond,
 	ReactivePromise,
 	TimeBond,

--- a/lib/index.js
+++ b/lib/index.js
@@ -27,6 +27,5 @@ module.exports = {
 	ReactiveBond,
 	ReactivePromise,
 	TimeBond,
-	TransformBond,
-	setDefaultTransformBondContext: TransformBond.setDefaultContext
+	TransformBond
 };

--- a/lib/transformBond.js
+++ b/lib/transformBond.js
@@ -104,7 +104,7 @@ class TransformBond extends ReactiveBond {
 
 			// Assue an undefined result means "reset".
 			if (typeof(result) === 'undefined') {
-				console.warn(`Transformation returned undefined: Applied ${f} to ${JSON.stringify(resolvedArguments)}.`);
+				console.warn(`Transformation returned undefined: Applied ${transform} to ${JSON.stringify(resolvedArguments)}.`);
 				this.reset();
 			} else if (result instanceof Promise) {
 				// If we're not latching, we reset while we resolve the

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "acorn": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz",
-      "integrity": "sha512-o96FZLJBPY1lvTuJylGA9Bk3t/GKPPJG8H0ydQQl01crzwJgspa4AEIq/pVTXigmK0PHVQhiAtn8WMBLL9D2WA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
+      "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w==",
       "dev": true
     },
     "acorn-jsx": {
@@ -28,21 +28,21 @@
       }
     },
     "ajv": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.5.tgz",
-      "integrity": "sha1-tjcjTT4mdetfefxlIkKoU6SMtJ8=",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
+      "integrity": "sha1-RBT/dKUIecII7l/cgm4ywwNUnto=",
       "dev": true,
       "requires": {
         "co": "4.6.0",
         "fast-deep-equal": "1.0.0",
-        "json-schema-traverse": "0.3.1",
-        "json-stable-stringify": "1.0.1"
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
       }
     },
     "ajv-keywords": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.0.tgz",
-      "integrity": "sha1-opbhf3v658HOT34N5T0pyzIWLfA=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+      "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
       "dev": true
     },
     "ansi-escapes": {
@@ -389,12 +389,12 @@
       "dev": true
     },
     "eslint": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.9.0.tgz",
-      "integrity": "sha1-doedJ0BoJhsZH+Dy9Wx0wvQgjos=",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.10.0.tgz",
+      "integrity": "sha512-MMVl8P/dYUFZEvolL8PYt7qc5LNdS2lwheq9BYa5Y07FblhcZqFyaUqlS8TW5QITGex21tV4Lk0a3fK8lsJIkA==",
       "dev": true,
       "requires": {
-        "ajv": "5.2.5",
+        "ajv": "5.3.0",
         "babel-code-frame": "6.26.0",
         "chalk": "2.3.0",
         "concat-stream": "1.6.0",
@@ -410,7 +410,7 @@
         "functional-red-black-tree": "1.0.1",
         "glob": "7.1.2",
         "globals": "9.18.0",
-        "ignore": "3.3.6",
+        "ignore": "3.3.7",
         "imurmurhash": "0.1.4",
         "inquirer": "3.3.0",
         "is-resolvable": "1.0.0",
@@ -452,7 +452,7 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "resolve": "1.4.0"
+        "resolve": "1.5.0"
       },
       "dependencies": {
         "debug": {
@@ -532,9 +532,9 @@
       "integrity": "sha512-xhPXrh0Vl/b7870uEbaumb2Q+LxaEcOQ3kS1jtIXanBAwpMre1l5q/l2l/hESYJGEFKuI78bp6Uw50hlpr7B+g==",
       "dev": true,
       "requires": {
-        "ignore": "3.3.6",
+        "ignore": "3.3.7",
         "minimatch": "3.0.4",
-        "resolve": "1.4.0",
+        "resolve": "1.5.0",
         "semver": "5.3.0"
       },
       "dependencies": {
@@ -574,7 +574,7 @@
       "integrity": "sha1-DJiLirRttTEAoZVK5LqZXd0n2H4=",
       "dev": true,
       "requires": {
-        "acorn": "5.1.2",
+        "acorn": "5.2.1",
         "acorn-jsx": "3.0.1"
       }
     },
@@ -622,7 +622,7 @@
       "dev": true,
       "requires": {
         "iconv-lite": "0.4.19",
-        "jschardet": "1.5.1",
+        "jschardet": "1.6.0",
         "tmp": "0.0.33"
       }
     },
@@ -630,6 +630,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
       "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
       "dev": true
     },
     "fast-levenshtein": {
@@ -792,9 +798,9 @@
       "dev": true
     },
     "ignore": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.6.tgz",
-      "integrity": "sha512-HrxmNxKTGZ9a3uAl/FNG66Sdt0G9L4TtMbbUQjP1WhGmSj0FOyHvSgx7623aGJvXfPOur8MwmarlHT+37jmzlw==",
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
+      "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
       "dev": true
     },
     "imurmurhash": {
@@ -930,9 +936,9 @@
       }
     },
     "jschardet": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.5.1.tgz",
-      "integrity": "sha512-vE2hT1D0HLZCLLclfBSfkfTTedhVj0fubHpJBHKwwUWX0nSbhPAfk+SG9rTX95BYNmau8rGFfCeaT6T5OW1C2A==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.6.0.tgz",
+      "integrity": "sha512-xYuhvQ7I9PDJIGBWev9xm0+SMSed3ZDBAmvVjbFR1ZRLAF+vlXcQu6cRI9uAlj81rzikElRVteehwV7DuX2ZmQ==",
       "dev": true
     },
     "json-schema-traverse": {
@@ -1434,9 +1440,9 @@
       }
     },
     "resolve": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
-      "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+      "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
       "dev": true,
       "requires": {
         "path-parse": "1.0.5"
@@ -1620,8 +1626,8 @@
       "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
       "dev": true,
       "requires": {
-        "ajv": "5.2.5",
-        "ajv-keywords": "2.1.0",
+        "ajv": "5.3.0",
+        "ajv-keywords": "2.1.1",
         "chalk": "2.3.0",
         "lodash": "4.17.4",
         "slice-ansi": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,5 @@
     "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-standard": "^3.0.1",
     "mocha": "^3.2.0"
-  },
-  "dependencies": {}
+  }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -2,13 +2,8 @@
 
 require('chai').should();
 
-const oo7 = require('../index');
+const { Bond, TimeBond, ReactiveBond, TransformBond } = require('../index');
 
-const Bond = oo7.Bond;
-const TimeBond = oo7.TimeBond;
-const ReactiveBond = oo7.ReactiveBond;
-// const ReactivePromise = oo7.ReactivePromise;
-const TransformBond = oo7.TransformBond;
 const testIntervals = TimeBond.testIntervals;
 
 describe('Bond', function () {

--- a/test/index.js
+++ b/test/index.js
@@ -95,14 +95,20 @@ describe('Bond', function () {
 	});
 
 	it('should use cache', () => {
-		let t = new Bond(true, 'myNumber');
+		const cacheConfig = {
+			id: 'myNumber',
+			stringify: JSON.stringify,
+			parse: JSON.parse
+		};
+
+		let t = new Bond(true, cacheConfig);
 		var x = 0;
 		let a = t.tie(_ => { x = _; });
 
 		t.trigger(42);
 		x.should.equal(42);
 
-		let u = new Bond(true, 'myNumber');
+		let u = new Bond(true, cacheConfig);
 		var y = 0;
 		let b = u.tie(_ => { y = _; });
 
@@ -117,14 +123,20 @@ describe('Bond', function () {
 	});
 
 	it('should switch cache master as necessary', () => {
-		let t = new Bond(true, 'myNumber');
+		const cacheConfig = {
+			id: 'myNumberTwo',
+			stringify: JSON.stringify,
+			parse: JSON.parse
+		};
+
+		let t = new Bond(true, cacheConfig);
 		var x = 0;
 		let a = t.tie(_ => { x = _; });
 
 		t.trigger(42);
 		x.should.equal(42);
 
-		let u = new Bond(true, 'myNumber');
+		let u = new Bond(true, cacheConfig);
 		var y = 0;
 		let b = u.tie(_ => { y = _; });
 
@@ -134,7 +146,7 @@ describe('Bond', function () {
 		x.should.equal(69);
 		y.should.equal(69);
 
-		let v = new Bond(true, 'myNumber');
+		let v = new Bond(true, cacheConfig);
 		var z = 0;
 		let c = v.tie(_ => { z = _; });
 

--- a/test/ipc.js
+++ b/test/ipc.js
@@ -63,7 +63,12 @@ describe('BondCache', function () {
 		let fireBonds = {};
 		class FireBond extends Bond {
 			constructor (uuid) {
-				super(true, uuid);
+				const cacheConfig = {
+					id: uuid,
+					stringify: JSON.stringify,
+					parse: JSON.parse
+				};
+				super(true, cacheConfig);
 			}
 			initialise () {
 				if (typeof fireBonds[this._uuid] === 'undefined') {

--- a/test/ipc.js
+++ b/test/ipc.js
@@ -105,10 +105,8 @@ describe('BondCache', function () {
 			let x = 0;
 			let xt = childBond.tie(n => x = n);
 
-			console.log('Scene mQ', scene.messageQueue);
 			scene.play();
 
-			console.log('fireBonds', fireBonds);
 			fireBonds['test/fireInstance'].length.should.equal(1);
 			fireBonds['test/fireInstance'][0].should.equal(fireInstance);
 
@@ -116,7 +114,6 @@ describe('BondCache', function () {
 			FireBond.fire('test/fireInstance', 69);
 			fireInstance._value.should.equal(69);
 
-			console.log('Scene mQ', scene.messageQueue);
 			x.should.equal(0);
 
 			scene.play();

--- a/test/ipc.js
+++ b/test/ipc.js
@@ -1,0 +1,127 @@
+/* eslint-disable  no-return-assign */
+
+require('chai').should();
+
+const { Bond, BondCache, BondProxy } = require('../index');
+
+class Setup {
+	constructor () {
+		let messageQueue = [];
+		let parentWindow = { localStorage: {}, messages: [], listeners: { message: [] } };
+		parentWindow.addEventListener = (type, f) => {
+			if (parentWindow.listeners[type]) {
+				parentWindow.listeners[type].push(f);
+			}
+		};
+		let childWindow = { localStorage: {}, parent: parentWindow, messages: [], listeners: { message: [] } };
+		childWindow.addEventListener = (type, f) => {
+			if (childWindow.listeners[type]) {
+				childWindow.listeners[type].push(f);
+			}
+		};
+
+		parentWindow.postMessage = m => messageQueue.push(
+			() => (parentWindow.listeners.message || []).forEach(l =>
+				l({source: childWindow, data: m})
+			)
+		);
+		childWindow.postMessage = m => messageQueue.push(
+			() => (childWindow.listeners.message || []).forEach(l =>
+				l({source: parentWindow, data: m})
+			)
+		);
+
+		this.messageQueue = messageQueue;
+		this.parentWindow = parentWindow;
+		this.childWindow = childWindow;
+	}
+
+	play () {
+		while (this.messageQueue.length > 0) {
+			this.messageQueue.splice(0, 1)[0]();
+		}
+	}
+}
+
+describe('BondCache', function () {
+	it('should have working scene', () => {
+		let scene = new Setup();
+
+		let roundTripsComplete = 0;
+		scene.parentWindow.addEventListener('message', m => { if (m.data === 'ping') m.source.postMessage('pong'); });
+		scene.parentWindow.addEventListener('message', m => { if (m.data === 'ping') m.source.postMessage('pong'); });
+		scene.childWindow.addEventListener('message', m => { if (m.data === 'pong') roundTripsComplete++; });
+		scene.childWindow.addEventListener('message', m => { if (m.data === 'pong') roundTripsComplete++; });
+		scene.parentWindow.postMessage('ping');
+		scene.play();
+
+		roundTripsComplete.should.equal(4);
+	});
+	it('should work', () => {
+		let scene = new Setup();
+
+		let fireBonds = {};
+		class FireBond extends Bond {
+			constructor (uuid) {
+				super(true, uuid);
+			}
+			initialise () {
+				if (typeof fireBonds[this._uuid] === 'undefined') {
+					fireBonds[this._uuid] = [];
+				}
+				fireBonds[this._uuid].push(this);
+			}
+			finalise () {
+				fireBonds[this._uuid].splice(fireBonds[this._uuid].indexOf(this), 1);
+				if (fireBonds[this._uuid].length === 0) {
+					delete fireBonds[this._uuid];
+				}
+			}
+		}
+		FireBond.fire = (uuid, value) => fireBonds[uuid].forEach(b => b.trigger(value));
+
+		let fireInstance = new FireBond('test/fireInstance');
+		fireInstance._noCache = true;
+		function fromUuid(uuid) {
+			if (uuid === 'test/fireInstance') { return fireInstance; }
+			return null;
+		}
+
+		Object.keys(fireBonds).length.should.equal(0);
+
+		let proxy = new BondProxy('test/', fromUuid, scene.parentWindow);
+		let cache = new BondCache(undefined, 'test/', scene.childWindow);
+		Bond.cache = cache;
+		let childBond = new FireBond('test/fireInstance');
+
+		Object.keys(fireBonds).length.should.equal(0);
+
+		{
+			let x = 0;
+			let xt = childBond.tie(n => x = n);
+
+			console.log('Scene mQ', scene.messageQueue);
+			scene.play();
+
+			console.log('fireBonds', fireBonds);
+			fireBonds['test/fireInstance'].length.should.equal(1);
+			fireBonds['test/fireInstance'][0].should.equal(fireInstance);
+
+			// Server fires.
+			FireBond.fire('test/fireInstance', 69);
+			fireInstance._value.should.equal(69);
+
+			console.log('Scene mQ', scene.messageQueue);
+			x.should.equal(0);
+
+			scene.play();
+			x.should.equal(69);
+
+			childBond.untie(xt);
+			fireBonds['test/fireInstance'].length.should.equal(1);
+
+			scene.play();
+			Object.keys(fireBonds).length.should.equal(0);
+		}
+	});
+});


### PR DESCRIPTION
From discussion with Gav:
so there were several use-cases of memoisation/caching i wanted:
* two equivalent items independently constructed in the same JS instance
* two equivalent items independently constructed in different JS instances but in the same domain
* two equivalent items that exist in the same JS domain but at different times
* two equivalent items independently constructed in different JS domains (but with the same parent frame) at the same time
* two equivalent items independently constructed in different JS domains (but with the same parent frame) at different times
when memoising items so you can avoid a costly look up at a future time there are two problems:
* you need to store the value persistently (e.g. with localStorage, but that requires the value to be stringifiable)
* you need to be able to cheaply determine whether the "correct" value has changed in the meantime without doing a costly query to the client (hard, and may need additional API support on parity side)
